### PR TITLE
Add feature to kick participants out of a room

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.gradle/*
-/.idea/*
+/backend/.idea/**
 /backend/.gradle/**
 /backend/build/*
 /frontend/build/*

--- a/backend/src/main/kotlin/de/solugo/messages/event/ParticipantKickedEvent.kt
+++ b/backend/src/main/kotlin/de/solugo/messages/event/ParticipantKickedEvent.kt
@@ -1,0 +1,12 @@
+package de.solugo.messages.event
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("participantKicked")
+data class ParticipantKickedEvent(
+    val roomId: String,
+    val participantId: String,
+    val initiatorParticipantId: String,
+) : Event()

--- a/backend/src/main/kotlin/de/solugo/messages/request/KickParticipantRequest.kt
+++ b/backend/src/main/kotlin/de/solugo/messages/request/KickParticipantRequest.kt
@@ -1,0 +1,11 @@
+package de.solugo.messages.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("kickParticipant")
+data class KickParticipantRequest(
+    val roomId: String,
+    val participantId: String,
+) : Request()

--- a/backend/src/main/kotlin/de/solugo/model/ContextMetrics.kt
+++ b/backend/src/main/kotlin/de/solugo/model/ContextMetrics.kt
@@ -71,4 +71,9 @@ class ContextMetrics(
         tag("value", "select")
         register(registry)
     }
+    val playerKickCounter = Counter.builder("app.event").run {
+        tag("target", "player")
+        tag("value", "kick")
+        register(registry)
+    }
 }

--- a/backend/src/main/kotlin/de/solugo/plugins/Api.kt
+++ b/backend/src/main/kotlin/de/solugo/plugins/Api.kt
@@ -69,10 +69,14 @@ fun Application.configureApi() {
                                         name = request.name,
                                         options = request.options,
                                     )
-
                                     is RevealRoomRequest -> context.revealRoom(
                                         roomId = request.roomId,
                                         visible = request.visible,
+                                    )
+                                    is KickParticipantRequest -> context.kickParticipant(
+                                        roomId = request.roomId,
+                                        participantId = request.participantId,
+                                        initiatorParticipantId = participantId
                                     )
 
                                 }

--- a/frontend/src/components/GameCard.tsx
+++ b/frontend/src/components/GameCard.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import {styled} from "@mui/material";
+import React, { useState } from "react";
+import {IconButton, styled} from "@mui/material";
 import classNames from "classnames";
+import { Cancel } from "@mui/icons-material";
 
 type GameCardType = "SELECT" | "VIEW" | "DISABLED"
 
@@ -11,6 +12,7 @@ interface GameCardProps {
     title?: string | undefined
     value?: string | null
     onClick?: () => void
+    onClickCancel?: () => void
 }
 
 const GameCard = (props: GameCardProps) => {
@@ -21,12 +23,19 @@ const GameCard = (props: GameCardProps) => {
         "card-selected": props.selected,
     })
 
+    const [showCancelButton, setShowCancelButton] = useState<'none' | 'block'>('none');
+
     return (
-        <div className={props.className}>
+        <div className={props.className} onMouseEnter={() => setShowCancelButton('block')} onMouseLeave={() => setShowCancelButton('none')}>
             <div className="title">
                 {props.title}
             </div>
             <div className={cardClasses} onClick={() => props.onClick?.()}>
+                {props.onClickCancel && 
+                    <IconButton className="cancel" aria-label="cancel" size="large" style={{display: showCancelButton}} onClick={() => props.onClickCancel?.()}>
+                        <Cancel />
+                    </IconButton>
+                }
                 <span>{props.value}</span>
             </div>
         </div>
@@ -77,6 +86,12 @@ export default styled(GameCard)((props) => (
             color: props.theme.palette.primary.contrastText,
             borderColor: props.theme.palette.secondary.main,
             backgroundColor: props.theme.palette.secondary.light,
+        },
+        ".cancel": {
+            position: "absolute",
+            top: "0",
+            left: "0",
+            padding: 0,
         },
     }
 ))

--- a/frontend/src/components/RoomDisplayView.tsx
+++ b/frontend/src/components/RoomDisplayView.tsx
@@ -33,6 +33,10 @@ const RoomDisplayView = (props: RoomDisplayViewProps) => {
         api?.resetRoom(roomId)
     }
 
+    function kickParticipant(participantId: string) {
+        api?.kickParticipant(roomId, participantId)
+    }
+
     let statTotal = 0
     const statValues: { [key: string]: number } = {}
 
@@ -64,6 +68,7 @@ const RoomDisplayView = (props: RoomDisplayViewProps) => {
                                 selected={participant.selection !== null}
                                 title={participant.name || "🕶️"}
                                 value={participant.role === "SPECTATOR" ? "👁️" : (room.visible ? participant.selection : "")}
+                                onClickCancel={participantId !== props.participantId ? () => kickParticipant(participantId): undefined}
                             />
                         </div>
                     )

--- a/frontend/src/logic/SessionApi.ts
+++ b/frontend/src/logic/SessionApi.ts
@@ -40,4 +40,12 @@ export class SessionApi {
         })
     }
 
+    kickParticipant(roomId: string, participantId: string) {
+        this.connection?.send({
+            type: 'kickParticipant',
+            roomId: roomId,
+            participantId: participantId
+        })
+    }
+
 }

--- a/frontend/src/logic/SessionConnection.ts
+++ b/frontend/src/logic/SessionConnection.ts
@@ -98,6 +98,10 @@ export class SessionConnection {
 
                     break
                 }
+                case 'participantKicked': {
+                    const room = session.rooms[event.roomId] =session.rooms[event.roomId] ?? new Room()
+                    delete room.participants?.[event.participantId]
+                }
             }
         }
 

--- a/frontend/src/logic/SessionEvent.ts
+++ b/frontend/src/logic/SessionEvent.ts
@@ -34,6 +34,12 @@ export interface ParticipantLeftRoomEvent {
     participantId: string
 }
 
+export interface ParticipantKicked {
+    type: 'participantKicked'
+    roomId: string
+    participantId: string
+}
+
 export interface ErrorEvent {
     type: 'error'
     message: string
@@ -46,3 +52,4 @@ export type SessionEvent =
     | ParticipantLeftRoomEvent
     | RoomInfoUpdatedEvent
     | RoomSelectionChangedEvent
+    | ParticipantKicked

--- a/frontend/src/logic/SessionRequest.ts
+++ b/frontend/src/logic/SessionRequest.ts
@@ -22,8 +22,15 @@ export interface UpdateSelectionRequest {
     selection: string | null
 }
 
+export interface KickParticipantRequest {
+    type: 'kickParticipant'
+    roomId: string
+    participantId: string
+}
+
 export type SessionRequest =
     | JoinRoomRequest
     | ResetRoomRequest
     | RevealRoomRequest
     | UpdateSelectionRequest
+    | KickParticipantRequest


### PR DESCRIPTION
Sometimes we have the problem by using the scrumpoker that participants curiously exit the browser without closing the websocket session correctly. Therefore the backend won´t remove the participants-object out of the room-object and the participant will stay in that room forever. This leads in duplicated participants in the next scrum-planning when the user begins a new connection with the same participant name.

For that reason i added a small button to the participants gamecards to kick participants out of a room.
![Picture of the new Buton](https://github.com/solugo/scrumpoker/assets/75687467/aeb7fa7c-d235-4723-9d97-4d21e9295356)
The Button only shows up by hovering the gamecard and only at the gamecards of other participants and not by hovering the own one.
Clicking that button will send a KickParticipantRequest to the backend. When the backend receives that request it will remove the asked participant out of the room. It sends a ParticipantKickedEvent to the kicked participant and the remaining participants in the room. The event also includes the id of the initiator of the kick-request. This will make it possible to show all users what actions had happened, which isn´t implemented yet. 